### PR TITLE
Remove necessidade da rota ser http

### DIFF
--- a/src/ExportaRest/Listener/DispatchListener.php
+++ b/src/ExportaRest/Listener/DispatchListener.php
@@ -26,7 +26,7 @@ class DispatchListener extends AbstractListenerAggregate
         
     }
     
-    protected function getNamespace(\Zend\Mvc\Router\Http\RouteMatch $routeMatch) {
+    protected function getNamespace(\Zend\Mvc\Router\RouteMatch $routeMatch) {
     	$controllerName = $routeMatch->getParam('controller');
     	$namespace = explode('\\',$controllerName);
     	return $namespace[0];


### PR DESCRIPTION
Estava dando erro quando passava alguma rota de console, mesmo quando a rota não usava o serviço
