### PR TITLE
Mudança para versão mais nova do DOMPDF

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"require" : {
 		"php" : ">=5.4.0",
 		"zendframework/zendframework" : ">=2.4.0",
-		"dino/dompdf-module" : ">=0.1"
+		"dino/dompdf-module" : "dev-master"
 	},
 	"autoload" : {
 		"psr-0" : {

--- a/src/ExportaRest/Listener/DispatchListener.php
+++ b/src/ExportaRest/Listener/DispatchListener.php
@@ -43,8 +43,8 @@ class DispatchListener extends AbstractListenerAggregate
     	   
     	if ($viewModel instanceof \ExportaRest\Pdf\ExportaPdfModel) {
     		$viewModel->setTemplateDir($namespace.'/'.$this->pdfTemplateDirName);
-    		$viewModel->setOption('paperOrientation', $e->getRequest()->getQuery('paper-orientation','portrait'));
-    		$viewModel->setOption('filename',$e->getRequest()->getQuery('filename','relatorio'));
+		$viewModel->setOption('display', $e->getRequest()->getQuery('paper-orientation','portrait'));
+                $viewModel->setOption('fileName',$e->getRequest()->getQuery('filename','relatorio'));
     		$e->setResult($viewModel);
     	} 
     }


### PR DESCRIPTION
Essa biblioteca está causando conflitos com outras bibliotecas com a **php-boleto-zf2**. 

Fiz algumas modificações para que ele passe a usar a versão dev-master do DOMPDF assim as bibliotecas ficarem todas na mesma versão dele.